### PR TITLE
fixed bug in prepare function and added trend and constant columns

### DIFF
--- a/src/distrib/dickeyfuller.rs
+++ b/src/distrib/dickeyfuller.rs
@@ -14,7 +14,8 @@
 
 use num_traits::Float;
 
-use super::{AlphaLevel, CalculationError, Regression};
+use super::{AlphaLevel, Regression};
+use crate::Error;
 
 /// Approximate Dickey-Fuller distribution for specific alpha levels
 /// for constant, no trend: $Δy_i = β_0 + β_1*y_{i-1} + ε_i$
@@ -24,7 +25,7 @@ use super::{AlphaLevel, CalculationError, Regression};
 pub fn constant_no_trend_critical_value<F: Float>(
     sz: usize,
     alpha: AlphaLevel,
-) -> Result<F, CalculationError> {
+) -> Result<F, crate::Error> {
     let (t, u, v, w) = match alpha {
         AlphaLevel::OnePercent => (-3.43035, -6.5393, -16.786, -79.433),
         AlphaLevel::TwoPointFivePercent => (-3.1175, -4.53235, -9.8824, -57.7669),
@@ -43,7 +44,7 @@ pub fn constant_no_trend_critical_value<F: Float>(
 pub fn no_constant_no_trend_critical_value<F: Float>(
     sz: usize,
     alpha: AlphaLevel,
-) -> Result<F, CalculationError> {
+) -> Result<F, crate::Error> {
     let (t, u, v, w) = match alpha {
         AlphaLevel::OnePercent => (-2.56574, -2.2358, -3.627, 0.),
         AlphaLevel::TwoPointFivePercent => (-2.222133, -1.15384, -3.4829, 17.17265),
@@ -62,7 +63,7 @@ pub fn no_constant_no_trend_critical_value<F: Float>(
 pub fn constant_trend_critical_value<F: Float>(
     sz: usize,
     alpha: AlphaLevel,
-) -> Result<F, CalculationError> {
+) -> Result<F, crate::Error> {
     let (t, u, v, w) = match alpha {
         AlphaLevel::OnePercent => (-3.95877, -9.0531, -28.428, -134.155),
         AlphaLevel::TwoPointFivePercent => (-3.657216, -6.488615, -17.7624, -85.32545),
@@ -90,7 +91,7 @@ pub fn get_critical_value<F: Float>(
     regression: Regression,
     sz: usize,
     alpha: AlphaLevel,
-) -> Result<F, CalculationError> {
+) -> Result<F, crate::Error> {
     match regression {
         Regression::Constant => constant_no_trend_critical_value(sz, alpha),
         Regression::ConstantAndTrend => constant_trend_critical_value(sz, alpha),
@@ -104,10 +105,10 @@ fn calculate_t_stat_from_estimators<F: Float>(
     v: f64,
     w: f64,
     sz: usize,
-) -> Result<F, CalculationError> {
+) -> Result<F, crate::Error> {
     let n = sz as f64;
     let t_stat = t + (u / n) + (v / n.powi(2)) + (w / n.powi(3));
-    let x = F::from(t_stat).ok_or(CalculationError::ConversionFailed)?;
+    let x = F::from(t_stat).ok_or(Error::ConversionFailed)?;
     Ok(x)
 }
 

--- a/src/distrib/dickeyfuller.rs
+++ b/src/distrib/dickeyfuller.rs
@@ -20,8 +20,8 @@ use crate::Error;
 /// Approximate Dickey-Fuller distribution for specific alpha levels
 /// for constant, no trend: $Δy_i = β_0 + β_1*y_{i-1} + ε_i$
 /// Source:
-/// estimation values: https://www.real-statistics.com/statistics-tables/augmented-dickey-fuller-table/
-/// equation: https://real-statistics.com/time-series-analysis/stochastic-processes/dickey-fuller-test/
+/// estimation values: <https://www.real-statistics.com/statistics-tables/augmented-dickey-fuller-table/>
+/// equation: <https://real-statistics.com/time-series-analysis/stochastic-processes/dickey-fuller-test/>
 pub fn constant_no_trend_critical_value<F: Float>(
     sz: usize,
     alpha: AlphaLevel,
@@ -39,8 +39,8 @@ pub fn constant_no_trend_critical_value<F: Float>(
 /// Approximate Dickey-Fuller distribution for specific alpha levels
 /// for constant, no trend: $Δy_i = β_1*y_{i-1} + ε_i$
 /// Source:
-/// estimation values: https://www.real-statistics.com/statistics-tables/augmented-dickey-fuller-table/
-/// equation: https://real-statistics.com/time-series-analysis/stochastic-processes/dickey-fuller-test/
+/// estimation values: <https://www.real-statistics.com/statistics-tables/augmented-dickey-fuller-table/>
+/// equation: <https://real-statistics.com/time-series-analysis/stochastic-processes/dickey-fuller-test/>
 pub fn no_constant_no_trend_critical_value<F: Float>(
     sz: usize,
     alpha: AlphaLevel,
@@ -58,8 +58,8 @@ pub fn no_constant_no_trend_critical_value<F: Float>(
 /// Approximate Dickey-Fuller distribution for specific alpha levels
 /// for constant, and trend: $Δy_i = β_0 + β_2*i + β_1*y_{i-1} + ε_i$
 /// Source:
-/// estimation values: https://www.real-statistics.com/statistics-tables/augmented-dickey-fuller-table/
-/// equation: https://real-statistics.com/time-series-analysis/stochastic-processes/dickey-fuller-test/
+/// estimation values: <https://www.real-statistics.com/statistics-tables/augmented-dickey-fuller-table/>
+/// equation: <https://real-statistics.com/time-series-analysis/stochastic-processes/dickey-fuller-test/>
 pub fn constant_trend_critical_value<F: Float>(
     sz: usize,
     alpha: AlphaLevel,

--- a/src/distrib/mod.rs
+++ b/src/distrib/mod.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 // Copyright (c) 2022. Sebastien Soudan
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,20 +36,3 @@ pub enum Regression {
     /// no constant, no trend e.g. Δy_i = β_1*y_{i-1}  + ε_i
     NoConstantNoTrend,
 }
-
-#[derive(Debug)]
-pub enum CalculationError {
-    ConversionFailed,
-    // Other error variants...
-}
-
-impl std::fmt::Display for CalculationError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::ConversionFailed => write!(f, "Conversion from f64 to generic float failed"),
-            // Other error variants...
-        }
-    }
-}
-
-impl std::error::Error for CalculationError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,4 +84,7 @@ pub enum Error {
     /// NotEnoughSamples
     #[error("Not enough samples")]
     NotEnoughSamples,
+    /// Failed to convert float.
+    #[error("Failed to convert float")]
+    ConversionFailed,
 }

--- a/src/regression.rs
+++ b/src/regression.rs
@@ -24,15 +24,14 @@ pub fn ols<F: Float + Scalar + RealField>(
     x: &DMatrix<F>,
 ) -> Result<(DVector<F>, DVector<F>), Error> {
     // Augment X with a column of 1s for the intercept - in first column
-    let a = x.clone();
-    let a = a.insert_column(0, F::from(1.0).unwrap());
-
+    // let a = x.clone();
+    // number of observations (rows)
     let n = x.nrows();
-    let k = a.ncols();
+    let k = x.ncols();
 
-    let at = &a.transpose();
+    let at = &x.transpose();
     // beta = (A'A)^-1 A'y
-    let ata = at * &a;
+    let ata = at * x;
     let ata_inv = &ata
         .try_inverse()
         .ok_or_else(|| Error::FailedToInvertMatrix("OLS failed to invert A.T*A".into()))?;
@@ -42,7 +41,7 @@ pub fn ols<F: Float + Scalar + RealField>(
     let beta_ = ata_inv * aty;
 
     // the predicted values
-    let y_hat = a * &beta_;
+    let y_hat = x * &beta_;
 
     // the residuals
     let residuals = y - y_hat;
@@ -64,36 +63,45 @@ pub fn ols<F: Float + Scalar + RealField>(
 #[cfg(test)]
 mod tests {
     use approx::assert_relative_eq;
-    use nalgebra::{DMatrix, DVector, Matrix};
+    use nalgebra::{DMatrix, DVector, Matrix, RealField, Scalar};
+    use num_traits::Float;
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
 
     use crate::utils::{gen_affine_data, gen_affine_data_with_whitenoise};
+    use crate::Error;
+
+    fn add_constant<F: Float + Scalar + RealField>(x: &mut DMatrix<F>) {
+        let constant = F::from(1.0).ok_or(Error::ConversionFailed).unwrap();
+        let a = vec![constant; x.nrows()];
+        x.extend(a)
+    }
 
     #[test]
     fn test_ols_f32() {
         let y = DVector::from_row_slice(&[1.0f32, 2.0, 3.0, 4.0, 5.0]);
-        let x = DMatrix::from_row_slice(5, 1, &[1.0f32, 2.0, 3.0, 4.0, 5.0]);
-
+        let mut x = DMatrix::from_row_slice(5, 1, &[1.0f32, 2.0, 3.0, 4.0, 5.0]);
+        add_constant(&mut x);
         let (beta_hat, t_stats) = super::ols(&y, &x).unwrap();
 
-        assert_eq!(beta_hat.get(0).unwrap().to_owned(), 0.0);
-        assert_eq!(beta_hat.get(1).unwrap().to_owned(), 1.0);
-        assert!(t_stats.get(0).unwrap().is_nan());
-        assert!(t_stats.get(1).unwrap().is_infinite());
+        assert_eq!(beta_hat.get(0).unwrap().to_owned(), 1.0);
+        assert_eq!(beta_hat.get(1).unwrap().to_owned(), 0.0);
+
+        assert!(t_stats.get(1).unwrap().is_nan());
+        assert!(t_stats.get(0).unwrap().is_infinite());
     }
 
     #[test]
     fn test_ols_f64() {
         let y = DVector::from_row_slice(&[1.0f64, 2.0, 3.0, 4.0, 5.0]);
-        let x = DMatrix::from_row_slice(5, 1, &[1.0f64, 2.0, 3.0, 4.0, 5.0]);
-
+        let mut x = DMatrix::from_row_slice(5, 1, &[1.0f64, 2.0, 3.0, 4.0, 5.0]);
+        add_constant(&mut x);
         let (beta_hat, t_stats) = super::ols(&y, &x).unwrap();
 
-        assert_eq!(beta_hat.get(0).unwrap().to_owned(), 0.0);
-        assert_eq!(beta_hat.get(1).unwrap().to_owned(), 1.0);
-        assert!(t_stats.get(0).unwrap().is_nan());
-        assert!(t_stats.get(1).unwrap().is_infinite());
+        assert_eq!(beta_hat.get(1).unwrap().to_owned(), 0.0);
+        assert_eq!(beta_hat.get(0).unwrap().to_owned(), 1.0);
+        assert!(t_stats.get(1).unwrap().is_nan());
+        assert!(t_stats.get(0).unwrap().is_infinite());
     }
 
     #[test]
@@ -103,17 +111,18 @@ mod tests {
         let mu = 4.0;
         let beta = 12.;
 
-        let (x, y) = gen_affine_data(sz, mu, beta);
+        let (mut x, y) = gen_affine_data(sz, mu, beta);
+        add_constant(&mut x);
 
         let (beta_hat, t_stats) = super::ols(&y, &x).unwrap();
-        let mu_hat = beta_hat.get(0).unwrap().to_owned();
-        let beta_hat = beta_hat.get(1).unwrap().to_owned();
+        let mu_hat = beta_hat.get(1).unwrap().to_owned();
+        let beta_hat = beta_hat.get(0).unwrap().to_owned();
 
         assert_relative_eq!(mu_hat, mu, epsilon = 0.1);
         assert_relative_eq!(beta_hat, beta, epsilon = 0.1);
 
-        let t_stat_mu = t_stats.get(0).unwrap().to_owned();
-        let t_stat_beta = t_stats.get(1).unwrap().to_owned();
+        let t_stat_mu = t_stats.get(1).unwrap().to_owned();
+        let t_stat_beta = t_stats.get(0).unwrap().to_owned();
 
         assert!(t_stat_mu > 1e3);
         assert!(t_stat_beta > 1e3);
@@ -128,20 +137,18 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(42);
 
-        let (x, y) = gen_affine_data_with_whitenoise(&mut rng, sz, mu, beta);
+        let (mut x, y) = gen_affine_data_with_whitenoise(&mut rng, sz, mu, beta);
+        add_constant(&mut x);
 
         let (beta_hat, t_stats) = super::ols(&y, &x).unwrap();
-        let mu_hat = beta_hat.get(0).unwrap().to_owned();
-        let beta_hat = beta_hat.get(1).unwrap().to_owned();
-
-        // println!("mu_hat: {}", mu_hat);
-        // println!("beta_hat: {}", beta_hat);
+        let mu_hat = beta_hat.get(1).unwrap().to_owned();
+        let beta_hat = beta_hat.get(0).unwrap().to_owned();
 
         assert_relative_eq!(mu_hat, mu, epsilon = 2.);
         assert_relative_eq!(beta_hat, beta, epsilon = 0.5);
 
-        let t_stat_mu = t_stats.get(0).unwrap().to_owned();
-        let t_stat_beta = t_stats.get(1).unwrap().to_owned();
+        let t_stat_mu = t_stats.get(1).unwrap().to_owned();
+        let t_stat_beta = t_stats.get(0).unwrap().to_owned();
 
         assert!(t_stat_mu > 100.);
         assert!(t_stat_beta > 100.);
@@ -158,13 +165,14 @@ mod tests {
 
         let y = DVector::from_row_slice((&x * beta_1 + &x2 * beta_2).add_scalar(beta_0).as_slice());
 
-        let x = Matrix::from_columns(&[x.column(0), x2.column(0)]);
+        let mut x = Matrix::from_columns(&[x.column(0), x2.column(0)]);
+        add_constant(&mut x);
 
         let (beta_hat, t_stats) = super::ols(&y, &x).unwrap();
 
-        assert_relative_eq!(beta_hat.get(0).unwrap().to_owned(), beta_0, epsilon = 1e-3);
-        assert_relative_eq!(beta_hat.get(1).unwrap().to_owned(), beta_1, epsilon = 1e-3);
-        assert_relative_eq!(beta_hat.get(2).unwrap().to_owned(), beta_2, epsilon = 1e-3);
+        assert_relative_eq!(beta_hat.get(0).unwrap().to_owned(), beta_1, epsilon = 1e-3);
+        assert_relative_eq!(beta_hat.get(1).unwrap().to_owned(), beta_2, epsilon = 1e-3);
+        assert_relative_eq!(beta_hat.get(2).unwrap().to_owned(), beta_0, epsilon = 1e-3);
         assert!(*t_stats.get(0).unwrap() > 1e3);
         assert!(*t_stats.get(1).unwrap() > 1e3);
         assert!(*t_stats.get(2).unwrap() > 1e3);
@@ -181,13 +189,13 @@ mod tests {
 
         let y = DVector::from_row_slice((&x * beta_1 + &x2 * beta_2).add_scalar(beta_0).as_slice());
 
-        let x = Matrix::from_columns(&[x.column(0), x2.column(0)]);
-
+        let mut x = Matrix::from_columns(&[x.column(0), x2.column(0)]);
+        add_constant(&mut x);
         let (beta_hat, t_stats) = super::ols(&y, &x).unwrap();
 
-        assert_relative_eq!(beta_hat.get(0).unwrap().to_owned(), beta_0, epsilon = 1e-3);
-        assert_relative_eq!(beta_hat.get(1).unwrap().to_owned(), beta_1, epsilon = 1e-3);
-        assert_relative_eq!(beta_hat.get(2).unwrap().to_owned(), beta_2, epsilon = 1e-3);
+        assert_relative_eq!(beta_hat.get(0).unwrap().to_owned(), beta_1, epsilon = 1e-3);
+        assert_relative_eq!(beta_hat.get(1).unwrap().to_owned(), beta_2, epsilon = 1e-3);
+        assert_relative_eq!(beta_hat.get(2).unwrap().to_owned(), beta_0, epsilon = 1e-3);
         assert!(*t_stats.get(0).unwrap() > 1e3);
         assert!(*t_stats.get(1).unwrap() > 1e3);
         assert!(*t_stats.get(2).unwrap() > 1e3);

--- a/src/tools/adf.rs
+++ b/src/tools/adf.rs
@@ -16,6 +16,7 @@
 use nalgebra::{DVector, RealField, Scalar};
 use num_traits::Float;
 
+use crate::distrib::Regression;
 use crate::prelude::tools::Report;
 use crate::regression::ols;
 use crate::{tools, Error};
@@ -28,7 +29,7 @@ pub fn constant_no_trend_test<F: RealField + Scalar + Float>(
     y: &DVector<F>,
     lag: usize,
 ) -> Result<Report<F>, Error> {
-    let (delta_y, x, size) = tools::prepare(y, lag)?;
+    let (delta_y, x, size) = tools::prepare(y, lag, Regression::Constant)?;
 
     let (_betas, t_stats) = ols(&delta_y, &x)?;
 

--- a/src/tools/adf.rs
+++ b/src/tools/adf.rs
@@ -34,13 +34,14 @@ pub fn constant_no_trend_test<F: RealField + Scalar + Float>(
     let (_betas, t_stats) = ols(&delta_y, &x)?;
 
     Ok(Report {
-        test_statistic: t_stats[1],
+        test_statistic: t_stats[0],
         size,
     })
 }
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
     use nalgebra::DVector;
 
     use crate::prelude::tools::dickeyfuller;
@@ -64,8 +65,12 @@ mod tests {
 
         let report = super::constant_no_trend_test(&y, lag).unwrap();
         assert_eq!(report.size, 8);
-        assert_eq!(report.test_statistic, 0.48612142266202985f64);
-        // statsmodels.tsa.stattools.adfuller(y, maxlag=2) gives:
+        assert_relative_eq!(
+            report.test_statistic,
+            0.48612142266202985f64,
+            epsilon = 1e-3
+        );
+        // statsmodels.tsa.stattools.adfuller(y, maxlag=2, regression='c') gives:
         // ADF Statistic: 0.486121
         // p-value: 0.984445
         // Critical Values:

--- a/src/tools/dickeyfuller.rs
+++ b/src/tools/dickeyfuller.rs
@@ -80,7 +80,7 @@ pub fn constant_no_trend_test<F: Float + Scalar + RealField>(
     let (delta_y, y_t_1, size) = prepare(series, 0, Regression::Constant)?;
 
     let (_betas, t_stats) = ols(&delta_y, &y_t_1)?;
-   
+
     Ok(Report {
         test_statistic: t_stats[0],
         size,

--- a/src/tools/dickeyfuller.rs
+++ b/src/tools/dickeyfuller.rs
@@ -80,9 +80,9 @@ pub fn constant_no_trend_test<F: Float + Scalar + RealField>(
     let (delta_y, y_t_1, size) = prepare(series, 0, Regression::Constant)?;
 
     let (_betas, t_stats) = ols(&delta_y, &y_t_1)?;
-
+    println!("t_stats: {}", t_stats);
     Ok(Report {
-        test_statistic: t_stats[1],
+        test_statistic: t_stats[0],
         size,
     })
 }

--- a/src/tools/dickeyfuller.rs
+++ b/src/tools/dickeyfuller.rs
@@ -80,7 +80,7 @@ pub fn constant_no_trend_test<F: Float + Scalar + RealField>(
     let (delta_y, y_t_1, size) = prepare(series, 0, Regression::Constant)?;
 
     let (_betas, t_stats) = ols(&delta_y, &y_t_1)?;
-    println!("t_stats: {}", t_stats);
+   
     Ok(Report {
         test_statistic: t_stats[0],
         size,

--- a/src/tools/dickeyfuller.rs
+++ b/src/tools/dickeyfuller.rs
@@ -15,6 +15,7 @@
 use nalgebra::{RealField, Scalar};
 use num_traits::Float;
 
+use crate::distrib::Regression;
 use crate::prelude::nalgebra::DVector;
 use crate::prelude::tools::Report;
 use crate::regression::ols;
@@ -76,7 +77,7 @@ use crate::Error;
 pub fn constant_no_trend_test<F: Float + Scalar + RealField>(
     series: &DVector<F>,
 ) -> Result<Report<F>, Error> {
-    let (delta_y, y_t_1, size) = prepare(series, 0)?;
+    let (delta_y, y_t_1, size) = prepare(series, 0, Regression::Constant)?;
 
     let (_betas, t_stats) = ols(&delta_y, &y_t_1)?;
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use nalgebra::{DMatrix, DVector, RealField, Scalar};
 use num_traits::Float;
 
-use crate::Error;
+use crate::{Error, regression, distrib::Regression};
 
 // Copyright (c) 2022. Sebastien Soudan
 //
@@ -36,6 +36,7 @@ pub struct Report<F: Debug + Clone> {
 pub(crate) fn prepare<F: RealField + Scalar + Float>(
     y: &DVector<F>,
     n: usize,
+    regression: Regression
 ) -> Result<(DVector<F>, DMatrix<F>, usize), Error> {
     let y_len = y.len();
 
@@ -56,6 +57,10 @@ pub(crate) fn prepare<F: RealField + Scalar + Float>(
     // we have to remove the first n elements of delta_y.
     let delta_y_output = delta_y.clone().remove_rows(0, n);
 
+    if regression == Regression::ConstantAndTrend {
+        //time trend column
+        let tt = &y.as_slice()[n..y_len];
+    }
     // Now for the second element of the tuple, we want to build a matrix of size (y_len
     // - 1 - n) x (n + 1)
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,7 +3,8 @@ use std::fmt::Debug;
 use nalgebra::{DMatrix, DVector, RealField, Scalar};
 use num_traits::Float;
 
-use crate::{Error, regression, distrib::Regression};
+use crate::distrib::Regression;
+use crate::Error;
 
 // Copyright (c) 2022. Sebastien Soudan
 //
@@ -32,11 +33,11 @@ pub struct Report<F: Debug + Clone> {
 
 /// Returns Delta(y) = y - y.shift(1) and a matrix made of:
 /// - a column of y.shift(1)
-/// - n columns of Delta(y).shit(n)
+/// - n columns of Delta(y).shift(n)
 pub(crate) fn prepare<F: RealField + Scalar + Float>(
     y: &DVector<F>,
     n: usize,
-    regression: Regression
+    regression: Regression,
 ) -> Result<(DVector<F>, DMatrix<F>, usize), Error> {
     let y_len = y.len();
 
@@ -57,10 +58,6 @@ pub(crate) fn prepare<F: RealField + Scalar + Float>(
     // we have to remove the first n elements of delta_y.
     let delta_y_output = delta_y.clone().remove_rows(0, n);
 
-    if regression == Regression::ConstantAndTrend {
-        //time trend column
-        let tt = &y.as_slice()[n..y_len];
-    }
     // Now for the second element of the tuple, we want to build a matrix of size (y_len
     // - 1 - n) x (n + 1)
 
@@ -83,6 +80,24 @@ pub(crate) fn prepare<F: RealField + Scalar + Float>(
         }
     }
 
+    if regression != Regression::NoConstantNoTrend {
+        // constant trend column
+        let constant = F::from(1.0).ok_or(Error::ConversionFailed)?;
+        let a = vec![constant; x.nrows()];
+        x.extend(a)
+    }
+
+    if regression == Regression::ConstantAndTrend {
+        // time trend column
+        let tt: Result<Vec<F>, crate::Error> = (1..x.nrows() + 1)
+            .map(|i| F::from(i as f64).ok_or(Error::ConversionFailed))
+            .collect();
+        match tt {
+            Ok(tt) => x.extend(tt),
+            Err(_) => return Err(Error::ConversionFailed),
+        };
+    }
+
     Ok((delta_y_output.into_owned(), x, y_len - n - 1))
 }
 
@@ -90,41 +105,156 @@ pub(crate) fn prepare<F: RealField + Scalar + Float>(
 mod tests {
     use nalgebra::{DMatrix, Matrix, Vector};
 
+    use crate::distrib::Regression;
+
     #[test]
-    fn test_prepare() {
+    fn test_prepare_constant() {
+        // Given
         let sz = 10;
         let n = 2;
 
         let y = vec![1., 3., 6., 10., 15., 21., 28., 36., 45., 55.];
         assert_eq!(y.len(), sz);
 
+        let row_count = sz - n - 1;
+        let column_count = n + 2;
+
+        let expected = DMatrix::from_row_slice(
+            row_count,
+            column_count,
+            &[
+                // y[t-1], Delta[y[t]].shift(1), Delta[y[t]].shift(2), constant
+                6., 3., 2., 1., //  row 0
+                10., 4., 3., 1., // row 1
+                15., 5., 4., 1., // row 2
+                21., 6., 5., 1., // row 3
+                28., 7., 6., 1., // row 4
+                36., 8., 7., 1., // row 5
+                45., 9., 8., 1., //  row 6
+            ],
+        );
+
         let y = Matrix::from(y);
 
-        let (delta_y, x, sz_) = super::prepare(&y, n).unwrap();
+        let regression = Regression::Constant;
 
+        // When
+        let (delta_y, x, sz_) = super::prepare(&y, n, regression).unwrap();
+
+        // Expected
         assert_eq!(sz_, sz - n - 1);
 
         // Delta[y[t]] = y[t] - y[t-1]
         assert_eq!(delta_y, Vector::from(vec![4., 5., 6., 7., 8., 9., 10.]));
 
-        assert_eq!(x.shape(), (sz - n - 1, n + 1));
+        assert_eq!(
+            x.shape(),
+            (row_count, column_count),
+            "The shape of x was not as expected"
+        );
+        assert_eq!(
+            x, expected,
+            "The output matrix x did not match the expected result"
+        );
+    }
+
+    #[test]
+    fn test_prepare_constant_and_trend() {
+        // Given
+        let sz = 10;
+        let n = 2;
+
+        let y = vec![1., 3., 6., 10., 15., 21., 28., 36., 45., 55.];
+        assert_eq!(y.len(), sz);
+
+        let row_count = sz - n - 1;
+        let column_count = n + 3;
+
+        let expected = DMatrix::from_row_slice(
+            row_count,
+            column_count,
+            &[
+                // y[t-1], Delta[y[t]].shift(1), Delta[y[t]].shift(2), constant, time trend
+                6., 3., 2., 1., 1., //  row 0
+                10., 4., 3., 1., 2., // row 1
+                15., 5., 4., 1., 3., // row 2
+                21., 6., 5., 1., 4., // row 3
+                28., 7., 6., 1., 5., // row 4
+                36., 8., 7., 1., 6., // row 5
+                45., 9., 8., 1., 7., //  row 6
+            ],
+        );
+
+        let y = Matrix::from(y);
+
+        let regression = Regression::ConstantAndTrend;
+
+        // When
+        let (delta_y, x, sz_) = super::prepare(&y, n, regression).unwrap();
+
+        // Expected
+        assert_eq!(sz_, sz - n - 1);
+
+        // Delta[y[t]] = y[t] - y[t-1]
+        assert_eq!(delta_y, Vector::from(vec![4., 5., 6., 7., 8., 9., 10.]));
 
         assert_eq!(
-            x,
-            DMatrix::from_row_slice(
-                sz - n - 1,
-                n + 1,
-                &[
-                    // y[t-1], Delta[y[t]].shift(1), Delta[y[t]].shift(2)
-                    6., 3., 2., //  row 0
-                    10., 4., 3., // row 1
-                    15., 5., 4., // row 2
-                    21., 6., 5., // row 3
-                    28., 7., 6., // row 4
-                    36., 8., 7., // row 5
-                    45., 9., 8. //  row 6
-                ],
-            )
+            x.shape(),
+            (row_count, column_count),
+            "The shape of x was not as expected"
+        );
+        assert_eq!(
+            x, expected,
+            "The output matrix x did not match the expected result"
+        );
+    }
+
+    #[test]
+    fn test_prepare_no_constant_no_trend() {
+        // Given
+        let sz = 10;
+        let n = 2;
+
+        let y = vec![1., 3., 6., 10., 15., 21., 28., 36., 45., 55.];
+        assert_eq!(y.len(), sz);
+
+        let row_count = sz - n - 1;
+        let column_count = n + 1;
+
+        let expected = DMatrix::from_row_slice(
+            row_count,
+            column_count,
+            &[
+                // y[t-1], Delta[y[t]].shift(1), Delta[y[t]].shift(2)
+                6., 3., 2., //  row 0
+                10., 4., 3., // row 1
+                15., 5., 4., // row 2
+                21., 6., 5., // row 3
+                28., 7., 6., // row 4
+                36., 8., 7., // row 5
+                45., 9., 8., //  row 6
+            ],
+        );
+
+        let y = Matrix::from(y);
+        let regression = Regression::NoConstantNoTrend;
+
+        // When
+        let (delta_y, x, sz_) = super::prepare(&y, n, regression).unwrap();
+
+        // Expected
+        assert_eq!(sz_, sz - n - 1);
+
+        // Delta[y[t]] = y[t] - y[t-1]
+        assert_eq!(delta_y, Vector::from(vec![4., 5., 6., 7., 8., 9., 10.]));
+        assert_eq!(
+            x.shape(),
+            (row_count, column_count),
+            "The shape of x was not as expected"
+        );
+        assert_eq!(
+            x, expected,
+            "The output matrix x did not match the expected result"
         );
     }
 
@@ -136,7 +266,7 @@ mod tests {
 
         let y = Matrix::from(y);
 
-        let res = super::prepare(&y, n);
+        let res = super::prepare(&y, n, Regression::Constant);
         assert!(res.is_err());
     }
 
@@ -148,7 +278,7 @@ mod tests {
 
         let y = Matrix::from(y);
 
-        let res = super::prepare(&y, n);
+        let res = super::prepare(&y, n, Regression::Constant);
         assert!(res.is_err());
     }
 
@@ -160,7 +290,7 @@ mod tests {
 
         let y = Matrix::from(y);
 
-        let res = super::prepare(&y, n);
+        let res = super::prepare(&y, n, Regression::Constant);
         assert!(res.is_err());
     }
 
@@ -172,7 +302,7 @@ mod tests {
 
         let y = Matrix::from(y);
 
-        let res = super::prepare(&y, n);
+        let res = super::prepare(&y, n, Regression::Constant);
         assert!(res.is_err());
     }
 
@@ -184,7 +314,7 @@ mod tests {
 
         let y = Matrix::from(y);
 
-        let res = super::prepare(&y, n);
+        let res = super::prepare(&y, n, Regression::Constant);
         assert!(res.is_err());
     }
 }


### PR DESCRIPTION
I think this is what is needed, however now some of the matrix are failing to invert in other tests. I know the python version uses sudo invert, but I don't know how that will affect performance. 